### PR TITLE
Simplify readEnv

### DIFF
--- a/site/posts/hkd-options.md
+++ b/site/posts/hkd-options.md
@@ -95,10 +95,8 @@ import System.Environment (lookupEnv, setEnv)
 import Text.Read (readMaybe)
 
 readEnv :: Read a => String -> IO (Maybe a)
-readEnv envKey = do
-    lookupEnv envKey >>= pure . \case
-        Just x -> readMaybe x
-        Nothing -> Nothing
+readEnv envKey =
+    (>>= readMaybe) <$> lookupEnv envKey
 ```
 
 This function looks up the given key in the environment, returning a

--- a/site/posts/hkd-options.md
+++ b/site/posts/hkd-options.md
@@ -127,7 +127,7 @@ import Data.Functor.Compose (Compose(..))
 
 -- Add a Compose to our helper
 readEnv :: Read a => String -> (IO `Compose` Maybe) a
-readEnv envKey = Compose $ do
+readEnv envKey = Compose $
     ...
 
 envOpts :: Options_ (IO `Compose` Maybe)


### PR DESCRIPTION
Three simplifications:

1. When there's only one expression inside of a `do`-block, the `do` keyword is unnecessary
2. `x >>= pure . f` is the same as `f <$> x`, for all `f` and `x`
3. `\case { Just x -> readMaybe x; Nothing -> Nothing }` is equivalent to `(>>= readMaybe)`