### PR TITLE
Fix duplicate Z in update timestamps

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -194,7 +194,7 @@ formatDate humanDate = toIsoDate parsedTime
       parseTimeOrError True defaultTimeLocale "%b %e, %Y" humanDate :: UTCTime
 
 toIsoDate :: UTCTime -> String
-toIsoDate = formatShow (withUTCDesignator $ utcTimeFormat (calendarFormat ExtendedFormat) (timeOfDayFormat ExtendedFormat))
+toIsoDate = formatShow (utcTimeFormat (calendarFormat ExtendedFormat) (timeOfDayFormat ExtendedFormat))
 
 buildFeed :: [Post] -> Action ()
 buildFeed posts = do


### PR DESCRIPTION
I noticed that my RSS reader wasn't parsing the correct dates and I suspect that this is why.